### PR TITLE
fix order of operands

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -15,10 +15,10 @@ module Main (main) where
     opsSolve :: [Int] -> String -> [Int]
     opsSolve s [] = s
     opsSolve (firstOnStack : secondOnStack : restOfStack) reversePolishNotation
-        | polishOp == "+" = opsSolve (firstOnStack   +   secondOnStack : restOfStack) stringRestOfNotation
-        | polishOp == "-" = opsSolve (firstOnStack   -   secondOnStack : restOfStack) stringRestOfNotation
-        | polishOp == "*" = opsSolve (firstOnStack   *   secondOnStack : restOfStack) stringRestOfNotation
-        | polishOp == "/" = opsSolve (firstOnStack `div` secondOnStack : restOfStack) stringRestOfNotation
+        | polishOp == "+" = opsSolve (secondOnStack   +   firstOnStack : restOfStack) stringRestOfNotation
+        | polishOp == "-" = opsSolve (secondOnStack   -   firstOnStack : restOfStack) stringRestOfNotation
+        | polishOp == "*" = opsSolve (secondOnStack   *   firstOnStack : restOfStack) stringRestOfNotation
+        | polishOp == "/" = opsSolve (secondOnStack `div` firstOnStack : restOfStack) stringRestOfNotation
         where (polishOp : restOfNotation) = words reversePolishNotation
               stringRestOfNotation = unwords restOfNotation
 


### PR DESCRIPTION
`4 2 2 / /` should return `[4]`. However, it returns `[0]` using the current operand order.

References:
* https://www.dcode.fr/reverse-polish-notation
* https://en.wikipedia.org/wiki/Reverse_Polish_notation